### PR TITLE
Update to new github permissions

### DIFF
--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   create-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     outputs:
       release_tag_name: ${{ env.release_tag_name }}
       build_meta: ${{ env.build_meta }}

--- a/.github/workflows/build-all.yml
+++ b/.github/workflows/build-all.yml
@@ -52,6 +52,8 @@ jobs:
   build-linux-amd64:
     runs-on: ubuntu-latest
     needs: create-release
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - name: Set up QEMU
@@ -77,6 +79,8 @@ jobs:
   build-linux-arm64:
     runs-on: ubuntu-latest
     needs: create-release
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - name: Set up QEMU
@@ -102,6 +106,8 @@ jobs:
   build-linux-arm:
     runs-on: ubuntu-latest
     needs: create-release
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - name: Set up QEMU
@@ -127,6 +133,8 @@ jobs:
   build-windows-amd64:
     runs-on: windows-2019
     needs: create-release
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       -
@@ -145,6 +153,8 @@ jobs:
   build-windows-i386:
     runs-on: windows-2019
     needs: create-release
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       -
@@ -163,6 +173,8 @@ jobs:
   build-windows-arm64:
     runs-on: windows-2019
     needs: create-release
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       -
@@ -181,6 +193,8 @@ jobs:
   build-macosx-amd64:
     runs-on: macos-12
     needs: create-release
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       -
@@ -246,6 +260,8 @@ jobs:
   build-macosx-arm64:
     runs-on: macos-12
     needs: create-release
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       -


### PR DESCRIPTION
Github updated the way permissions work recently, thus without these modifications the workflow is unable to create releases and upload assets it seems.